### PR TITLE
Missing #default_value property in the 'target_platform' form element.

### DIFF
--- a/hosting_quickmigrate.module
+++ b/hosting_quickmigrate.module
@@ -75,7 +75,8 @@ function hosting_task_quickmigrate_form($node) {
         '#type' => 'radio',
         '#title' => $platform->title,
         '#parents' => array('parameters', 'target_platform'),
-        "#return_value" => $platform->nid,
+        '#default_value' => $platform->nid,
+        '#return_value' => $platform->nid,
         '#description' => $description,
       );
       if ($status['error']) {


### PR DESCRIPTION
Missing #default_value property in the 'target_platform' form element.